### PR TITLE
fix: add path resolution for module imports in main script

### DIFF
--- a/src/uithub_expander/__main__.py
+++ b/src/uithub_expander/__main__.py
@@ -1,5 +1,8 @@
 import argparse
 import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent.resolve()))
 
 from uithub_expander.parser import UithubExpander
 


### PR DESCRIPTION
- Added path resolution to ensure the main script can correctly import the UithubExpander module from the parent directory.
- This change improves the module's accessibility and resolves potential import errors.